### PR TITLE
Add Czech fakenews sites

### DIFF
--- a/source/fake-news/combined.txt
+++ b/source/fake-news/combined.txt
@@ -1,0 +1,8 @@
+ac24.cz
+aeronet.cz
+ceskoaktualne.cz
+eurozpravy.cz
+parlamentnilisty.cz
+sputniknews.com
+stars24.cz
+stredoevropan.cz

--- a/source/fake-news/wildcard.list
+++ b/source/fake-news/wildcard.list
@@ -1,0 +1,8 @@
+ac24.cz
+aeronet.cz
+ceskoaktualne.cz
+eurozpravy.cz
+parlamentnilisty.cz
+sputniknews.com
+stars24.cz
+stredoevropan.cz


### PR DESCRIPTION
Source of this list is "Nadační fond nezávislé žurnalistiky".
It's Czech non-profit organization for funding independent journalists.
Manually checked all entries and they are well-known fakenews sites in Czech
Republic.

URL:
https://www.nfnz.cz/

List:
https://rating.nfnz.cz/
(only lowest rating C)

Methodology for rating is explained here:
https://rating.nfnz.cz/methodology/

Wikipedia:
https://cs.wikipedia.org/wiki/Nada%C4%8Dn%C3%AD_fond_nez%C3%A1visl%C3%A9_%C5%BEurnalistiky